### PR TITLE
Header styling Closes #230

### DIFF
--- a/style.css
+++ b/style.css
@@ -103,6 +103,12 @@ To safely make customizations to the theme:
 	# RESET CSS
 --------------------------------------------------------------*/
 
+/*variables*/
+
+:root {
+	--header-nav-height: 4.5rem;
+}
+
 /* http://meyerweb.com/eric/tools/css/reset/ v2.0 | 20110126 License: none (public domain) */
 html, body, div, span, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
@@ -759,6 +765,7 @@ a#logo > img {
 	vertical-align: top;
 	-webkit-transition: all .2s linear;
 	transition: all .2s linear;
+	height: var(--header-nav-height) !important;
 }
 
 .septera-over-menu #site-header-main {
@@ -6501,7 +6508,7 @@ body.mobile .main {min-height:0;}
 
 nav#humanities-menu {
     display: block;
-    margin-top: 65px;
+    margin-top: var(--header-nav-height);
 }
 
 nav#humanities-menu li {


### PR DESCRIPTION
Resized header, adjusted nav menu, etc. in order to allow content after the header image to show. 
![image](https://user-images.githubusercontent.com/80128034/127179094-4251157d-282e-49fe-b175-70d584a8aa06.png)
Note: Yes, the code changes are in px :( Unfortunately, the header height can only be adjusted through customization on the frontend of the website (css can't override that), and the height is already set in pixels there. 