### PR TITLE
Link Styling throughout the site Closes #289

### DIFF
--- a/resources/css/directory.css
+++ b/resources/css/directory.css
@@ -352,7 +352,7 @@ ul.directory-list.filterable {
 
 /*link styling*/
 .research_areas_list a {
-	text-decoration:underline;
+	text-decoration: underline;
 }
 
 ul.directory-list.filterable a {

--- a/style.css
+++ b/style.css
@@ -6765,12 +6765,12 @@ h3.odhFirstTitle{
     margin-bottom: 20px;
 	text-align: center;
 }
-.odhBoxTitle{
-    color: #141414 !important;
+.entry-content .odhBoxTitle{
+    color: #141414;
     font-size: 19px;
 }
-.odhBoxInner a:hover {
-	text-decoration: none !important;
+.entry-content .odhBoxInner a:hover {
+	text-decoration: none;
 }
 .odhBoxDescription{
 	color: #141414;
@@ -6884,6 +6884,16 @@ a:-webkit-any-link {
 }
 
 .entry-content a:hover {
+	text-decoration: underline;
+	color:#002E5D;
+}
+
+.text-content a {
+	text-decoration: underline;
+	color:#0057b8;
+}
+
+.text-content a:hover {
 	text-decoration: underline;
 	color:#002E5D;
 }


### PR DESCRIPTION
Links are colored and underlined and will change color on hover:
![image](https://user-images.githubusercontent.com/80128034/135486329-09d8aaf0-65e8-4f82-b2f6-6d0903739822.png)

Additionally, links that we don't want colored and/or underlined aren't:
![image](https://user-images.githubusercontent.com/80128034/135486449-01431654-83cc-4f22-a536-9cfbe92fe033.png)
![image](https://user-images.githubusercontent.com/80128034/135486488-16ad2e92-adf4-454d-b1c0-615b9cd91610.png)
