### PR TITLE
Nav link fix Closes #304

### DIFF
--- a/style.css
+++ b/style.css
@@ -6874,7 +6874,7 @@ h2.projectMainContODH{
 
 /* style for links */
 
-a:-webkit-any-link {
+.menu-odhmain-container a {
 	text-decoration: none;
 }
 


### PR DESCRIPTION
No underlines across different browsers (Firefox, Chrome, Edge). See [here](https://humstaging.byu.edu/odh/).