### PR TITLE
Added text editor and author to custom blog posts Closes #390

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -225,7 +225,7 @@ function byuh_setup() {
         'has_archive'         => false, 
         'hierarchical'        => false,
         'menu_position'       => 20,
-        'supports'            => array('title', 'thumbnail', 'excerpt'),
+        'supports'            => array('title', 'thumbnail', 'excerpt', 'editor', 'author'),
         'menu_icon'           => 'dashicons-feedback',
 
         // For the REST API v2


### PR DESCRIPTION
Text editor and author field now appear:

![image](https://user-images.githubusercontent.com/80128034/157087069-ec9b648d-0878-4bbb-8f80-2e1e42a79b9d.png)
